### PR TITLE
Fixed: "Get Started" and "transform your placement" button now redirects to register instead of Login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4533,6 +4533,13 @@
         "react": "*"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-media-recorder": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/react-media-recorder/-/react-media-recorder-1.7.1.tgz",

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -141,7 +141,7 @@ const LandingPage = () => {
                       ? "bg-gradient-to-r from-purple-600 to-indigo-600 text-white"
                       : "bg-white text-purple-600 hover:bg-gray-50"
                   }`}
-                  onClick={() => navigate("/auth")}
+                  onClick={() => navigate("/register")}
                 >
                   <span className="relative z-10 flex items-center space-x-2">
                     <Zap className="w-4 h-4" />
@@ -257,7 +257,7 @@ const LandingPage = () => {
                       whileHover={{ scale: 1.02 }}
                       whileTap={{ scale: 0.98 }}
                       onClick={() => {
-                        navigate("/auth");
+                        navigate("/register");
                         setIsMobileMenuOpen(false);
                       }}
                       className={`w-full text-left px-4 py-3 rounded-xl transition-all duration-300 flex items-center space-x-3 ${
@@ -394,7 +394,7 @@ const LandingPage = () => {
                 <motion.button
                   whileHover={{ scale: 1.05, y: -2 }}
                   whileTap={{ scale: 0.95 }}
-                  onClick={() => navigate("/auth")}
+                  onClick={() => navigate("/register")}
                   className="group relative inline-flex items-center justify-center px-6 py-4 text-lg font-semibold text-purple-700 bg-white rounded-2xl shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden"
                 >
                   <span className="relative z-10 flex items-center space-x-2">
@@ -802,7 +802,7 @@ const LandingPage = () => {
             viewport={{ once: true }}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            onClick={() => navigate("/interview")}
+            onClick={() => navigate("/register")}
             className="bg-purple-600 dark:bg-purple-700 text-white px-8 py-4 rounded-xl font-semibold text-lg 
                        hover:bg-purple-700 dark:hover:bg-purple-800 transform hover:scale-105 transition-all duration-200 
                        shadow-xl hover:shadow-2xl inline-flex items-center space-x-2"


### PR DESCRIPTION
✅ Fixed: "Get Started" and "transform your placement" button now redirects to register instead of Login

Updated the navigation link on the landing page.

"Get Started" now correctly leads to the register page (/signup) for new users.

Improves user onboarding experience.

#87 