### PR TITLE
fix: scroll position now resets on route change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 import { motion } from "framer-motion";
 
 import useLenis from "./components/useLenis"; // Import the custom hook for smooth scrolling
+import ScrollToTop from "./components/ScrollToTop";
 
 
 function App() {
@@ -32,6 +33,7 @@ function App() {
   useLenis();
   return (
     <Router>
+      <ScrollToTop/>
       <div className="min-h-screen bg-gray-50 flex flex-col justify-between">
         <div>
           <Routes>

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
## 📄 Description
Implemented a scroll-to-top behavior on route change.  
This enhances user experience by ensuring that each new page starts from the top, rather than retaining the scroll position of the previous page.

## ✅ Checklist
- [x] My code follows the project’s coding guidelines.
- [x] I have tested these changes locally.
- [x] I have added necessary documentation/comments.
- [x] I have linked the related issue.

## 🔗 Related Issue
Closes #89 

## 🙏 Additional Notes
- Added a reusable `ScrollToTop` component.
- Imported and used it in `App.jsx` to ensure it runs globally on route change.
