### PR TITLE
FIX(UI): Implement dark mode for feedback page

### DIFF
--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -69,15 +69,17 @@ const FeedbackForm = () => {
 
   if (submitted) {
     return (
-      <motion.div 
+      <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
-        className="min-h-screen bg-gradient-to-br from-purple-600 via-purple-700 to-indigo-800 flex items-center justify-center p-4"
+        // FIX: The outer background should also respect the theme for consistency.
+        className="min-h-screen bg-gray-100 dark:bg-slate-900 flex items-center justify-center p-4"
       >
-        <div className="bg-white rounded-2xl shadow-2xl p-8 max-w-md w-full text-center">
+        {/* FIX: Changed bg-white and text colors */}
+        <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-2xl p-8 max-w-md w-full text-center">
           <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">Thank You!</h2>
-          <p className="text-gray-600 mb-6">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">Thank You!</h2>
+          <p className="text-gray-600 dark:text-gray-400 mb-6">
             Your feedback has been sent to our team. We appreciate your input!
           </p>
           <button
@@ -92,41 +94,46 @@ const FeedbackForm = () => {
   }
 
   return (
-    <motion.div 
+    <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="min-h-screen bg-gradient-to-br from-purple-600 via-purple-700 to-indigo-800 flex items-center justify-center p-4"
+      // FIX: The outer background should also respect the theme for consistency.
+      className="min-h-screen bg-gray-100 dark:bg-slate-900 flex items-center justify-center p-4"
     >
-      <motion.div 
+      <motion.div
         initial={{ y: 50, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
-        className="bg-white rounded-2xl shadow-2xl p-8 max-w-2xl w-full"
+        // FIX: Changed bg-white to support dark mode
+        className="bg-white dark:bg-slate-800 rounded-2xl shadow-2xl p-8 max-w-2xl w-full"
       >
         {/* Header */}
         <div className="text-center mb-8">
           <div className="flex items-center justify-center space-x-2 mb-4">
-            <Brain className="w-8 h-8 text-purple-600" />
-            <span className="text-2xl font-bold text-gray-900">Placify Feedback</span>
+            <Brain className="w-8 h-8 text-purple-600 dark:text-purple-400" />
+            {/* FIX: Changed text colors */}
+            <span className="text-2xl font-bold text-gray-900 dark:text-gray-100">Placify Feedback</span>
           </div>
-          <h2 className="text-3xl font-bold text-gray-900 mb-2">
+          <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
             How was your experience?
           </h2>
-          <p className="text-gray-600">
+          <p className="text-gray-600 dark:text-gray-400">
             Your feedback helps us improve our AI interview platform
           </p>
         </div>
 
         {error && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-center space-x-2">
-            <AlertCircle className="w-5 h-5 text-red-600" />
-            <span className="text-red-700">{error}</span>
+            // FIX: Added dark mode styles for the error alert
+          <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-500/30 rounded-lg flex items-center space-x-2">
+            <AlertCircle className="w-5 h-5 text-red-600 dark:text-red-400" />
+            <span className="text-red-700 dark:text-red-400">{error}</span>
           </div>
         )}
 
         <form onSubmit={handleSubmit} className="space-y-8">
           {/* Star Rating */}
           <div className="text-center">
-            <h3 className="text-lg font-semibold mb-4">Overall Rating</h3>
+            {/* FIX: Changed text color */}
+            <h3 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">Overall Rating</h3>
             <div className="flex justify-center space-x-2">
               {[1,2,3,4,5].map(star => (
                 <motion.button
@@ -137,11 +144,12 @@ const FeedbackForm = () => {
                   onClick={() => setRating(star)}
                   className="focus:outline-none"
                 >
-                  <Star 
-                    className={`w-10 h-10 ${
-                      star <= rating 
-                        ? 'text-yellow-400 fill-current' 
-                        : 'text-gray-300'
+                  <Star
+                    className={`w-10 h-10 transition-colors ${
+                      star <= rating
+                        ? 'text-yellow-400 fill-current'
+                        // FIX: Changed inactive star color for dark mode
+                        : 'text-gray-300 dark:text-gray-600'
                     }`}
                   />
                 </motion.button>
@@ -151,7 +159,8 @@ const FeedbackForm = () => {
               <motion.p
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                className="text-purple-600 font-medium mt-2"
+                // FIX: Changed text color
+                className="text-purple-600 dark:text-purple-400 font-medium mt-2"
               >
                 {rating === 5 ? 'Excellent!' : 
                  rating === 4 ? 'Very Good!' :
@@ -163,34 +172,39 @@ const FeedbackForm = () => {
 
           {/* Testimonial */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">Tell us more (optional)</h3>
+            {/* FIX: Changed text color */}
+            <h3 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">Tell us more (optional)</h3>
+            {/* FIX: Added dark mode styles for textarea */}
             <textarea
               value={testimonial}
               onChange={(e) => setTestimonial(e.target.value)}
               rows="4"
-              className="w-full p-4 border border-gray-300 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-purple-500"
+              className="w-full p-4 bg-transparent dark:bg-slate-700 border border-gray-300 dark:border-gray-600 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-purple-500 text-gray-800 dark:text-gray-200 placeholder-gray-500 dark:placeholder-gray-400"
               placeholder="Share your experience with Placify..."
               maxLength="500"
             />
-            <div className="text-right text-sm text-gray-500 mt-1">
+            {/* FIX: Changed text color */}
+            <div className="text-right text-sm text-gray-500 dark:text-gray-400 mt-1">
               {testimonial.length}/500
             </div>
           </div>
 
           {/* Improvement Suggestions */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">What would you improve?</h3>
-            <div className="grid grid-cols-2 gap-3">
+            {/* FIX: Changed text color */}
+            <h3 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">What would you improve?</h3>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {improvementOptions.map(option => (
                 <motion.button
                   key={option}
                   type="button"
                   whileHover={{ scale: 1.02 }}
                   onClick={() => handleImprovementToggle(option)}
+                  // FIX: Added dark mode styles for active and inactive buttons
                   className={`p-3 text-left border-2 rounded-lg transition ${
                     improvements.includes(option)
-                      ? 'border-purple-500 bg-purple-50 text-purple-700'
-                      : 'border-gray-200 hover:border-purple-300'
+                      ? 'border-purple-500 bg-purple-50 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300'
+                      : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-purple-300 dark:hover:border-purple-500'
                   }`}
                 >
                   <span className="text-sm font-medium">{option}</span>


### PR DESCRIPTION
## Description

This PR resolves a UI inconsistency where the Feedback Page did not respect the application's dark mode setting. The fix ensures a cohesive user experience by making the page's theme sync with the rest of the application.

---
## Closes: #232 
 
 
## Screenshots


<img width="753" height="894" alt="image" src="https://github.com/user-attachments/assets/de9e0144-20ab-4248-8652-23339459ae55" />


---

## How to Test
Check out this branch and run the application.

Enable dark mode using the theme toggle.

Navigate to the /feedback page.

Verify that the feedback page now renders correctly in dark mode, with a dark background and light text.

---

## Acknowledgement
Thank you for the opportunity to contribute to this project as part of GSSoC '25. I've learned a lot and am grateful for the chance to help improve Placify.

---

## NOTE: Could you please add the appropriate labels to this PR (e.g., bug, UI, GSSoC'25) and add me as the assignee? Thank you!