### PR TITLE
Fix/chatbot contrast

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -277,7 +277,7 @@ const Chatbot = () => {
                   onChange={(e) => setInput(e.target.value)}
                   onKeyPress={handleKeyPress}
                   placeholder="Type your message..."
-                  className="w-full p-3 pr-12 text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all max-h-32 min-h-[44px]"
+                  className="w-full p-3 pr-12 text-sm bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-200 border border-gray-200 dark:border-gray-700 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all max-h-32 min-h-[44px]"
                   rows="1"
                   style={{ 
                     height: 'auto',


### PR DESCRIPTION
# Fix: Low Contrast Text in Chatbot Input Field

## Description
Fixed accessibility issue where user input text in the chatbot was nearly invisible due to dark font color on dark background. Updated CSS to use light-colored text for proper contrast and readability.

**Closes:** #230 

---

## Type of Change
- [x] Bug fix
- [x] Accessibility improvement

---

## Changes Made
- Updated chatbot input field CSS to use light font color (white/off-white)
- Enhanced text visibility while maintaining design consistency

---

## Steps to Test
1. Open the "Placify Assistant" chatbot widget
2. Click in the message input box and start typing
3. Verify text is now clearly visible with proper contrast

---

## Screenshots

**Before:**

<img width="436" height="538" alt="image" src="https://github.com/user-attachments/assets/b92b06ce-bf08-49d5-8e35-168c7e3bc2dd" />


**After:**

<img width="400" height="512" alt="image" src="https://github.com/user-attachments/assets/ebf129d8-4cfd-4c86-b886-24136218b903" />


---

## Acknowledgment
Thank you for the opportunity to contribute to the Placify project and help improve accessibility for all users.

## Post-Merge Request
**@maintainers:** Please assign this PR to me after merging and add labels.

---
