### PR TITLE
[FIX]: #294 Clicking on Logo Does Not Navigate to Home Page

### DIFF
--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Link } from 'react-router-dom';
 import { useNavigate } from "react-router-dom";
 import {
   ArrowRight,
@@ -90,19 +91,19 @@ const LandingPage = () => {
                 transition={{ duration: 0.6, delay: 0.1 }}
                 className="flex items-center space-x-3"
               >
-                {/* Added onClick to scroll to top when Brain icon is clicked */}
+                {/* onClick and cursor-pointer are on the icon's div */}
                 <motion.div
                   whileHover={{ rotate: 360 }}
                   transition={{ duration: 0.6 }}
                   className="p-2 bg-gradient-to-br from-purple-500 to-indigo-600 rounded-xl shadow-lg cursor-pointer"
-                  onClick={() =>
-                    window.scrollTo({ top: 0, behavior: "smooth" })
-                  }
+                  onClick={() => window.location.href = "/"}
                 >
                   <Brain className="w-6 h-6 lg:w-7 lg:h-7 text-white" />
                 </motion.div>
+                {/* onClick and cursor-pointer are also on the text's span */}
                 <span
-                  className={`text-2xl lg:text-3xl font-bold transition-all duration-500 ${
+                  onClick={() => window.location.href = "/"}
+                  className={`text-2xl lg:text-3xl font-bold transition-all duration-500 cursor-pointer ${
                     isScrolled
                       ? "bg-gradient-to-r from-purple-600 to-indigo-600 dark:from-purple-400 dark:to-indigo-400 bg-clip-text text-transparent"
                       : "text-white"


### PR DESCRIPTION
## Description
This PR fixes the issue where clicking on the application logo did not navigate the user to the home page. Users typically expect the logo to serve as a shortcut to the home screen, but previously it provided no navigation functionality.

With this fix:
- If the user is on another page, clicking the logo will redirect them to the home page.
- If the user is already on the home page, clicking the logo will perform a full reload, ensuring the state is reset.

## Changes Made
- Added `window.location.href = "/"` to the logo’s `onClick` handler.
- Ensured logo is styled with a `cursor: pointer` for clear interactivity.
- Verified that navigation and reload behavior works consistently across routes.

## Screenshots / Demo

https://github.com/user-attachments/assets/193ae790-24a0-4598-be92-5a40458c696e


https://github.com/user-attachments/assets/244945c6-94cf-4e71-8ebb-e1e1530231fb



## Closes Issue
Fixes #294
