### PR TITLE
Fix theme toggle overlap by moving button into header

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -5,12 +5,9 @@ import { useNavigate } from "react-router-dom";
 
 const Navbar = () => {
   const navigate = useNavigate();
-
   return (
     <nav className="flex justify-between items-center px-6 py-4 bg-white shadow-md">
       <h1 className="text-2xl font-bold text-blue-700">Dashboard</h1>
-
-      
     </nav>
   );
 };

--- a/src/pages/Student/Dashboard.jsx
+++ b/src/pages/Student/Dashboard.jsx
@@ -129,7 +129,7 @@ const StudentDashboard = () => {
   return (
     <div className={`min-h-screen transition-colors duration-300 ${themeClasses}`}>
       {/* Theme Toggle */}
-      <div className="absolute top-4 right-4 z-10">
+      {/*<div className="absolute top-4 right-4 z-10">
         <button
           onClick={toggleTheme}
           className="p-3 rounded-full bg-white dark:bg-gray-800 shadow-lg hover:shadow-xl transition-all duration-300 border dark:border-gray-700"
@@ -140,7 +140,7 @@ const StudentDashboard = () => {
             <Moon className="w-5 h-5 text-gray-700" />
           )}
         </button>
-      </div>
+      </div>*/}
 
       {/* Header */}
       <div className="bg-white dark:bg-gray-800 border-b dark:border-gray-700 px-6 py-4">
@@ -156,10 +156,29 @@ const StudentDashboard = () => {
           </div>
           
           <div className="flex items-center gap-4">
-            <div className="relative">
-              <Bell className="w-6 h-6 text-gray-600 dark:text-gray-400 cursor-pointer hover:text-purple-600" />
-              <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full"></div>
-            </div>
+            <div className="flex items-center gap-4">
+             <div className="relative">
+             <Bell className="w-6 h-6 text-gray-600 dark:text-gray-400 cursor-pointer hover:text-purple-600" />
+    <div className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full"></div>
+  </div>
+  <button className="flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-lg hover:shadow-lg transition-all duration-300">
+    <RefreshCw className="w-4 h-4" />
+    Sync Data
+  </button>
+
+  {/* Theme Toggle */}
+  <button
+    onClick={toggleTheme}
+    className="p-3 rounded-full bg-white dark:bg-gray-800 shadow-lg hover:shadow-xl transition-all duration-300 border dark:border-gray-700"
+  >
+    {isDarkMode ? (
+      <Sun className="w-5 h-5 text-yellow-500" />
+    ) : (
+      <Moon className="w-5 h-5 text-gray-700" />
+    )}
+  </button>
+</div>
+
             <button className="flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-purple-600 to-pink-600 text-white rounded-lg hover:shadow-lg transition-all duration-300">
               <RefreshCw className="w-4 h-4" />
               Sync Data


### PR DESCRIPTION
## What does this PR fix?
Fixed the theme toggle icon and profile overlap in dashboard. Move the theme toggle button to the header of dashboard for betterment of user experience.

 Fixes #334 

## Images for reference
<img width="1366" height="768" alt="Screenshot (344)" src="https://github.com/user-attachments/assets/b1ce80b0-83cb-4c38-86c0-de6cd0a7ca92" />
 