### PR TITLE
Fix theme toggle icon

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -26,9 +26,9 @@ const ThemeToggle = () => {
         className="w-5 h-5"
       >
         {darkMode ? (
-          <Moon className="w-5 h-5 text-blue-400" />
-        ) : (
           <Sun className="w-5 h-5 text-yellow-500" />
+        ) : (
+          <Moon className="w-5 h-5 text-blue-400" />
         )}
       </motion.div>
 


### PR DESCRIPTION
## What does this PR do?
Fixed the theme icons to display icons opposite to current theme of page

Fixes #333 

## Images for reference
<img width="1366" height="768" alt="Screenshot (348)" src="https://github.com/user-attachments/assets/d46b1c24-dea1-437e-a349-c391be232a03" />
<img width="1366" height="768" alt="Screenshot (349)" src="https://github.com/user-attachments/assets/c54c3d55-6b58-42ef-a174-d2c4ff72e553" />
 