### PR TITLE
[FIX]: #297 Resume Builder Shows 404 on Page Reload 

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+      {
+        "source": "/(.*)",
+        "destination": "/index.html"
+      }
+    ]
+  }


### PR DESCRIPTION
### 📌 Summary
This PR fixes the bug where reloading the **Resume Builder** page resulted in a `404: NOT_FOUND` error.  
The issue was caused by incorrect route handling on deployment.  

Earlier, a `netlify.toml` file was created for routing, but since the project is deployed on **Vercel**, I have added a `vercel.json` configuration file to correctly handle page reloads.


https://github.com/user-attachments/assets/bc4ddd34-14bf-4738-b147-bacf9d2154ac


### 📈 Impact
- closes #297 
- Corrects deployment-specific routing (Vercel).  
- Improves reliability and workflow continuity for users.
