### PR TITLE
remove duplicate resume builder

### DIFF
--- a/src/pages/Student/Jobs.jsx
+++ b/src/pages/Student/Jobs.jsx
@@ -1017,7 +1017,7 @@ const App = () => {
 
   const navigation = [
     { id: 'jobs', label: 'Jobs', icon: Briefcase },
-    { id: 'resume', label: 'Resume Builder', icon: FileText },
+    //{ id: 'resume', label: 'Resume Builder', icon: FileText },
     { id: 'interviews', label: 'Interview Experience', icon: Users }
   ];
 


### PR DESCRIPTION
## What does this PR do?
Removed the duplicate Resume Builder from Jobs page which is already present on sidebar.

Fixes #365 

## Images for reference
<img width="1366" height="768" alt="Screenshot (365)" src="https://github.com/user-attachments/assets/b5b64c3b-7dc8-40c3-9b8f-8c09008f7a44" />
