### PR TITLE
Fix: Prevent copy/paste in password fields

### DIFF
--- a/src/components/FormInput.jsx
+++ b/src/components/FormInput.jsx
@@ -7,7 +7,9 @@ export default function FormInput({
   value,
   onChange,
   required = false,
-  focusColor = 'purple' // Default focus color is purple
+  focusColor = 'purple', // Default focus color is purple
+  onCopy,
+  onPaste
 }) {
   const [showPassword, setShowPassword] = useState(false);
 
@@ -31,6 +33,8 @@ export default function FormInput({
           type={type === 'password' ? (showPassword ? 'text' : 'password') : type}
           value={value}
           onChange={onChange}
+          onCopy={onCopy}
+          onPaste={onPaste}
           required={required}
           className={`
             w-full px-3 py-2 border border-gray-300 rounded-md

--- a/src/pages/register/CompanyForm.jsx
+++ b/src/pages/register/CompanyForm.jsx
@@ -166,6 +166,8 @@ export default function CompanyForm() {
               onChange={(e) =>
                 setFormData({ ...formData, password: e.target.value })
               }
+              onCopy={(e) => e.preventDefault()}
+              onPaste={(e) => e.preventDefault()}
               required
               className="dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400"
             />
@@ -177,6 +179,7 @@ export default function CompanyForm() {
               onChange={(e) =>
                 setFormData({ ...formData, confirmPassword: e.target.value })
               }
+              onPaste={(e) => e.preventDefault()}
               required
               className="dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400"
             />

--- a/src/pages/register/EmployeeForm.jsx
+++ b/src/pages/register/EmployeeForm.jsx
@@ -160,6 +160,8 @@ export default function EmployeeForm() {
               onChange={(e) =>
                 setFormData({ ...formData, password: e.target.value })
               }
+              onCopy={(e) => e.preventDefault()}
+              onPaste={(e) => e.preventDefault()}
               required
               className="dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400"
             />
@@ -170,6 +172,7 @@ export default function EmployeeForm() {
               onChange={(e) =>
                 setFormData({ ...formData, confirmPassword: e.target.value })
               }
+              onPaste={(e) => e.preventDefault()}
               required
               className="dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400"
             />

--- a/src/pages/register/InstitutionForm.jsx
+++ b/src/pages/register/InstitutionForm.jsx
@@ -172,6 +172,8 @@ export default function InstitutionForm() {
               onChange={(e) =>
                 setFormData({ ...formData, password: e.target.value })
               }
+              onCopy={(e) => e.preventDefault()}
+              onPaste={(e) => e.preventDefault()}
               required
               className="dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400"
             />
@@ -183,6 +185,7 @@ export default function InstitutionForm() {
               onChange={(e) =>
                 setFormData({ ...formData, confirmPassword: e.target.value })
               }
+              onPaste={(e) => e.preventDefault()}
               required
               className="dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400"
             />

--- a/src/pages/register/StudentForm.jsx
+++ b/src/pages/register/StudentForm.jsx
@@ -176,6 +176,8 @@ export default function StudentForm() {
               onChange={(e) =>
                 setFormData({ ...formData, password: e.target.value })
               }
+              onCopy={(e) => e.preventDefault()}
+              onPaste={(e) => e.preventDefault()}
               required
             />
             <FormInput
@@ -185,6 +187,7 @@ export default function StudentForm() {
               onChange={(e) =>
                 setFormData({ ...formData, confirmPassword: e.target.value })
               }
+              onPaste={(e) => e.preventDefault()}
               required
             />
 


### PR DESCRIPTION
closes #377 

**Summary** 

Added onCopy and onPaste handlers to the password fields, and onPaste to the confirm password fields in CompanyForm, EmployeeForm, InstitutionForm, and StudentForm to enhance password security by preventing copy-paste actions.