### PR TITLE
Added withdraw application and applied jobs endpoints

### DIFF
--- a/server/routes/job.js
+++ b/server/routes/job.js
@@ -1,7 +1,7 @@
 import verifyToken from "../middleware/authMiddleware.js";
 import express from "express";
 const router = express.Router();
-import { createJob,updateJob,getJobs ,deleteJob,applyForJob} from "../controllers/jobController.js";
+import { createJob,updateJob,getJobs ,deleteJob,applyForJob,getAppliedJobs,withdrawApplication} from "../controllers/jobController.js";
 
 router.get("/",getJobs)
 
@@ -10,7 +10,8 @@ router.post("/",verifyToken(["company"]),createJob)
 router.patch("/:id",verifyToken(["company"]),updateJob)
 router.delete("/:id", verifyToken(["company","admin"]), deleteJob); // DELETE job
 router.post("/:id/apply", verifyToken(["student"]), applyForJob); // Apply for job
-
+router.get("/applied", verifyToken(["student"]), getAppliedJobs);   // View applied jobs
+router.delete("/:id/withdraw", verifyToken(["student"]), withdrawApplication); // Withdraw application
 
 
 export default router;


### PR DESCRIPTION
closes #456 
**1. Get Applied Jobs (Student Perspective)**
Implemented an API endpoint GET /api/jobs/applied?page&limit that allows students to view all jobs they have applied for.
**Each job response includes:**

- Job details → title, type, domain, location, salary, description, requirements, responsibilities.
- Company details → name, website, profileImage.
- Student-specific details → resume, appliedAt.
- Added pagination support (page, limit) for better performance.
- Returns 404 if no applications are found.
- Response is structured in a frontend-friendly format for direct rendering.

**2. Withdraw Job Application**

Added API endpoint DELETE /api/jobs/:jobId/withdraw to allow students to withdraw their job applications.

**Validations:**

- Only the student who applied can withdraw their own application.
- Prevents withdrawal if no prior application exists.

**On success:**

- Removes the student entry from the job’s applicants list.
- Returns updated job details with a success message.

