### PR TITLE
 Integrate Interview Experience Backend with Frontend & Auto-Approve Submissions

### DIFF
--- a/server/controllers/interviewExperienceController.js
+++ b/server/controllers/interviewExperienceController.js
@@ -51,7 +51,8 @@ export const createInterviewExperience = async (req, res) => {
             difficulty,
             rating: parseInt(rating),
             experience,
-            tips: tips || ''
+            tips: tips || '',
+            isApproved: true // Always approved by default
         });
 
         const savedExperience = await newExperience.save();
@@ -94,9 +95,9 @@ export const getAllInterviewExperiences = async (req, res) => {
         } = req.query;
 
         // Basic filter for public and approved experiences only
-        const filter = { 
+        const filter = {
             isPublic: true,
-            isApproved: true 
+            isApproved: true
         };
 
         // Calculate pagination

--- a/server/server.js
+++ b/server/server.js
@@ -52,6 +52,7 @@ app.use("/api/students", studentRoutes); // New route for student progress track
 app.use("/api/ats", atsRoutes);
 app.use("/api/resume/score", resumeScoreRoutes); // New route for resume score persistence - MUST come before /api/resume
 app.use("/api/resume", resumeRoutes);
+app.use("/api/interviewExperience", interviewExperienceRoutes);
 
 // NOTE: Missing leading slash would break the route (returning index.html or 404 to frontend)
 app.use("/api/jobs", jobRoute);


### PR DESCRIPTION
closes #415 

**Description:**

* Integrated the **Interview Experience backend API** with the frontend React page.
* Frontend now fetches **real interview experiences** from the backend. If no data exists, **mock data** is displayed.
* Submitting the form sends a **POST request** to the backend, and the new experience is **instantly visible** in the list.
* Added **toast notifications** for success and error states on both `GET` and `POST` requests.
* Refactored frontend code to use a **single `fetchExperiences` function** for both initial load and after submission.
* Backend now sets `isApproved: true` by default for new submissions → all new experiences are **auto-approved & instantly visible**.
* Backend filtering clarified: only experiences with `isPublic: true` **and** `isApproved: true` are returned to the frontend.
* Added **troubleshooting notes** for why older data may not appear (requires manual approval).
* Improved **user feedback** and **data consistency** between backend and frontend.

---

