### PR TITLE
fixed the chatbot's text color in dark mode

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -323,7 +323,7 @@ const Chatbot = () => {
                   onChange={(e) => setInput(e.target.value)}
                   onKeyPress={handleKeyPress}
                   placeholder="Type your message..."
-                  className="w-full p-2 sm:p-3 text-xs sm:text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all"
+                  className="w-full p-2 sm:p-3 text-xs sm:text-sm text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all"
                   rows="1"
                   style={{
                     height: "auto",


### PR DESCRIPTION
## Description 
Fixed the font color of the input text in chatbot's message when dark mode is active.

## Closes #474 

## Screenshot
<img width="307" height="96" alt="image" src="https://github.com/user-attachments/assets/70629e6f-fd75-42f9-9009-67a7784a08f7" />

## Context 
Thanks for the opportunity.
