### PR TITLE
Added API endpoints for getting Jobs On company portal

### DIFF
--- a/server/routes/Payment.js
+++ b/server/routes/Payment.js
@@ -1,6 +1,5 @@
 import express from "express";
-import Payment from "../models/Payment.js";
-import Coupon from "../models/Coupon.js";
+
 
 const router = express.Router();
 

--- a/server/routes/job.js
+++ b/server/routes/job.js
@@ -1,7 +1,7 @@
 import verifyToken from "../middleware/authMiddleware.js";
 import express from "express";
 const router = express.Router();
-import { createJob,updateJob,getJobs ,deleteJob,applyForJob,getAppliedJobs,withdrawApplication} from "../controllers/jobController.js";
+import { createJob,updateJob,getJobs ,deleteJob,applyForJob,getAppliedJobs,withdrawApplication,getCompanyJobs} from "../controllers/jobController.js";
 
 router.get("/",getJobs)
 
@@ -12,6 +12,10 @@ router.delete("/:id", verifyToken(["company","admin"]), deleteJob); // DELETE jo
 router.post("/:id/apply", verifyToken(["student"]), applyForJob); // Apply for job
 router.get("/applied", verifyToken(["student"]), getAppliedJobs);   // View applied jobs
 router.delete("/:id/withdraw", verifyToken(["student"]), withdrawApplication); // Withdraw application
+router.get("/mine", verifyToken(["company"]), getCompanyJobs);// companyjobs on company's portal 
+
+
+
 
 
 export default router;


### PR DESCRIPTION
closes #521 

**Summary**

This PR adds the getCompanyJobs controller which allows a logged-in company to view its own posted jobs with pagination, sorting, and multiple optional filters.

**Key Features**

- 🔒 Authentication-based access: Company can only see its own jobs (req.user.userId).
- 📄 Pagination support with page & limit (default 10, max 50).


**🔍 Filters added:**

- Status (Open / Closed)
- Title (case-insensitive search using regex)
- Description (case-insensitive search using regex)
- Date range (fromDate, toDate applied on createdAt)

🏢 Company info population in response (name, email, industry, website, employeeCount, profileImage).

⚡ Performance optimized with Promise.all for parallel DB queries (count + fetch).

🛠 Error handling with structured error response.