### PR TITLE
Add z-index to icons in AuthPage for improved layering

### DIFF
--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -190,7 +190,7 @@ const AuthPage = () => {
                 Email address
               </label>
               <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none z-10">
                   <Mail className="w-5 h-5 text-gray-400 dark:text-gray-500" />
                 </div>
                 <motion.input
@@ -223,7 +223,7 @@ const AuthPage = () => {
                 Password
               </label>
               <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none z-10">
                   <Lock className="w-5 h-5 text-gray-400 dark:text-gray-500" />
                 </div>
                 <motion.input


### PR DESCRIPTION
closes #543 
Fix the layering so icons are visible
<img width="612" height="265" alt="image" src="https://github.com/user-attachments/assets/59597bbd-3bc7-4c5d-856c-5d4d0f0639bb" />
