### PR TITLE
feat: Implement Backend Dry-Run for Python Code

### DIFF
--- a/server/controllers/dryRunController.js
+++ b/server/controllers/dryRunController.js
@@ -1,0 +1,78 @@
+// dryRunController.js
+// Controller for Python dry-run validation using Gemini AI via @google/generative-ai
+// Accepts user code and test cases, compares AI output, returns result
+
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || "YOUR_GEMINI_API_KEY";
+
+// Initialize Gemini client
+const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
+const model = genAI.getGenerativeModel({ model: "gemini-1.5-pro" });
+
+/**
+ * POST /api/dryrun
+ * Body: {
+ *   code: string (Python code),
+ *   testCases: [
+ *     { input: string, expectedOutput: string }
+ *   ]
+ * }
+ * Returns: {
+ *   success: boolean,
+ *   results: [ { input, expectedOutput, aiOutput, passed } ],
+ *   message: string
+ * }
+ */
+export const dryRunPython = async (req, res) => {
+  try {
+    const { code, testCases } = req.body;
+    if (!code || !Array.isArray(testCases)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid input." });
+    }
+
+    // Run all test cases in parallel
+    const results = await Promise.all(
+      testCases.map(async (tc) => {
+        let aiOutput = "";
+        let passed = false;
+
+        try {
+          const prompt = `Given the following Python code:\n${code}\n\nRun it with input:\n${tc.input}\n\nWhat is the output? Respond with only the output.`;
+
+          const result = await model.generateContent(prompt);
+          aiOutput = result.response.text().trim();
+
+          passed = aiOutput === tc.expectedOutput.trim();
+        } catch (err) {
+          console.error("Gemini API error:", err.message);
+          aiOutput = "[Gemini API error]";
+        }
+
+        return {
+          input: tc.input,
+          expectedOutput: tc.expectedOutput,
+          aiOutput,
+          passed,
+        };
+      })
+    );
+
+    const allPassed = results.every((r) => r.passed);
+
+    return res.json({
+      success: allPassed,
+      results,
+      message: allPassed
+        ? "All test cases passed."
+        : "Some test cases failed.",
+    });
+  } catch (error) {
+    console.error("Dry-run error:", error);
+    return res
+      .status(500)
+      .json({ success: false, message: "Internal server error." });
+  }
+};

--- a/server/routes/dryrun.js
+++ b/server/routes/dryrun.js
@@ -1,0 +1,13 @@
+// dryrun.js
+// Express route for Python dry-run validation
+
+const express = require('express');
+const { dryRunPython } = require('../controllers/dryRunController');
+
+const router = express.Router();
+
+// POST /api/dryrun
+// Body: { code: string, testCases: [{ input, expectedOutput }] }
+router.post('/dryrun', dryRunPython);
+
+module.exports = router;


### PR DESCRIPTION
## Description
This PR introduces a secure and scalable backend system for **Python dry-run validation** using **Gemini AI (v1.5-pro)**.  
Instead of executing user-submitted Python code directly, the system leverages Gemini to simulate execution for provided test cases, compare outputs, and return standardized results.

## Related Issue
closes #557

## Changes Made
- [x] Implemented `dryRunController.js` with Gemini AI integration using `@google/generative-ai`.
- [x] Added `/api/dryrun` endpoint for validating Python code against test cases.
- [x] Parallelized test case evaluation for improved efficiency.
- [x] Standardized API response format (success, results, message).
- [x] Implemented robust error handling for invalid inputs and Gemini API failures.
- [x] Added comments for easier frontend/backend integration.

## Usage
**Endpoint:**  
`POST /api/dryrun`

**Request Body:**
```json
{
  "code": "print(input())",
  "testCases": [
    { "input": "Hello", "expectedOutput": "Hello" }
  ]
}
````

**Response:**

```json
{
  "success": true,
  "results": [
    {
      "input": "Hello",
      "expectedOutput": "Hello",
      "aiOutput": "Hello",
      "passed": true
    }
  ],
  "message": "All test cases passed."
}
```

## Security & Impact

* ✅ No direct execution of user code — all validation is handled by Gemini AI.
* ✅ Scalable for multi-user and concurrent requests.
* ✅ Safe for public-facing applications.

## Checklist

* [ ] Code is formatted with Prettier and follows clean code practices.
* [ ] Only necessary files are modified.
* [ ] API key securely read from `process.env.GEMINI_API_KEY`.
* [ ] Tested with multiple inputs and edge cases.
* [ ] No breaking changes to existing endpoints.

## Additional Notes

* Requires installation of `@google/generative-ai`.
* Requires a valid Gemini API key via `GEMINI_API_KEY` env variable.
* Can be extended for other languages or models in the future.

```
