### PR TITLE
Fix: Scroll to top when any page loads

### DIFF
--- a/src/pages/register/CompanyForm.jsx
+++ b/src/pages/register/CompanyForm.jsx
@@ -2,6 +2,7 @@ import { Building2, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
+import { useEffect } from "react";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { CheckCircle, XCircle } from "lucide-react";
@@ -33,6 +34,11 @@ export default function CompanyForm() {
     number: false,
     special: false,
   });
+
+    useEffect(() => {
+      window.scrollTo(0, 0);
+    }, []);
+
 
   const validatePassword = (password) => {
     const rules = {

--- a/src/pages/register/EmployeeForm.jsx
+++ b/src/pages/register/EmployeeForm.jsx
@@ -1,5 +1,6 @@
 import { Briefcase, Loader2 } from "lucide-react";
 import { useState } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { ToastContainer, toast } from "react-toastify";
@@ -33,6 +34,11 @@ export default function EmployeeForm() {
     number: false,
     special: false,
   });
+
+    useEffect(() => {
+      window.scrollTo(0, 0);
+    }, []);
+
 
   const validatePassword = (password) => {
     const rules = {

--- a/src/pages/register/InstitutionForm.jsx
+++ b/src/pages/register/InstitutionForm.jsx
@@ -61,6 +61,11 @@ export default function InstitutionForm() {
     return rules;
   };
 
+  // Scroll to top when component mounts
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   const handlePasswordChange = (e) => {
     const newPassword = e.target.value;
     setFormData({ ...formData, password: newPassword });

--- a/src/pages/register/StudentForm.jsx
+++ b/src/pages/register/StudentForm.jsx
@@ -2,6 +2,7 @@ import { GraduationCap, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
+import { useEffect } from "react";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import FormInput from "../../components/FormInput";
@@ -114,6 +115,10 @@ export default function StudentForm() {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   const passwordValidationRules = [
     { label: "At least 8 characters", key: "length" },


### PR DESCRIPTION
closes #613 

### Description
Previously, when navigating back to the StudentForm page, the page would retain the previous scroll position (middle of the page) instead of starting from the top. This PR ensures that the page always scrolls to the top when the component mounts.

### Changes
- Added `useEffect` with `window.scrollTo(0, 0)` in `StudentForm` to reset scroll position on mount.

### How to Test
1. Navigate to the StudentForm page and scroll down.  
2. Go to another page.  
3. Click the browser's “Back” button to return to StudentForm.  
4. Verify that the page loads from the top.
