### PR TITLE
Forgot Password Page/Option Added

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,6 +80,7 @@ import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import PaymentGateway from "./components/payment/PaymentGateway";
 import CursorTrail from "./components/CursorTrail";
+import ForgotPass from "./pages/ForgotPass";
 
 const AppWrapper = () => {
   useLenis();
@@ -97,6 +98,7 @@ const AppWrapper = () => {
             {/* Public */}
             <Route path="/" element={<LandingPage />} />
             <Route path="/auth" element={<AuthPage />} />
+            <Route path="/forgot-password" element={<ForgotPass />} />
             <Route path="/register" element={<RoleSelectionPage />} />
             <Route path="/resume" element={<Resume />} />
             <Route path="/register/student" element={<StudentForm />} />

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -8,6 +8,7 @@ import "react-toastify/dist/ReactToastify.css";
 // Import our new apiClient instead of axios directly
 import apiClient from "../api/apiClient"; // <-- CHANGE HERE
 import { useAuth } from "../context/AuthContext";
+import { Link } from "react-router-dom";
 
 const AuthPage = () => {
   const navigate = useNavigate();
@@ -268,6 +269,13 @@ const AuthPage = () => {
               </div>
             </motion.div>
                 {passerror && <p className="text-red-500 text-sm">{passerror}</p>}
+
+            {/* Forgot password */}
+            <p style={{ marginTop: "20px", textAlign: "center" }}>
+              <Link to="/forgot-password" style={{ color: "#9333EA", textDecoration: "none" }}>
+                Forgot Password?
+              </Link>
+            </p>
 
             {/* Submit Button */}
             <motion.button

--- a/src/pages/ForgotPass.jsx
+++ b/src/pages/ForgotPass.jsx
@@ -1,0 +1,175 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion } from "framer-motion";
+import { Brain, Eye, EyeOff } from "lucide-react";
+
+function ForgotPass() {
+  const [email, setEmail] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const navigate = useNavigate();
+
+  const handleReset = () => {
+    if (newPassword.length < 6) {
+      alert("Password cannot be less than 6 characters");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      alert("Passwords Doesn't match");
+      return;
+    }
+    alert("Password reset successful!");
+    navigate("/Auth");
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-[#0f172a]">
+      <div className="bg-[#1e293b] p-8 rounded-2xl shadow-lg w-full max-w-sm">
+        {/* Header */}
+        <motion.div
+          initial={{ y: 20, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+          className="text-center mb-8"
+        >
+          <motion.div
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{
+              duration: 0.6,
+              delay: 0.5,
+              type: "spring",
+              stiffness: 200,
+            }}
+            className="flex items-center justify-center pr-6 space-x-2 mb-4"
+          >
+            <Brain className="w-8 h-8 text-purple-600 dark:text-purple-400" />
+            <span className="text-2xl font-bold text-gray-900 dark:text-white">
+              Placify
+            </span>
+          </motion.div>
+          <motion.h2
+            initial={{ y: 10, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.6, delay: 0.6 }}
+            className="text-3xl font-bold text-gray-900 dark:text-white"
+          >
+            Reset Password
+          </motion.h2>
+          <motion.p
+            initial={{ y: 10, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.6, delay: 0.7 }}
+            className="text-gray-600 dark:text-gray-300 mt-2"
+          >
+            Enter details to reset your account password
+          </motion.p>
+        </motion.div>
+
+        {/* Email */}
+        <motion.div
+          initial={{ x: -20, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          transition={{ duration: 0.5, delay: 0.9 }}
+        >
+          <div className="mb-4">
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2"
+            >
+              Email address
+            </label>
+            <input
+              type="email"
+              placeholder="Enter your email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full p-3 rounded-lg bg-[#0f172a] text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              required
+            />
+          </div>
+        </motion.div>
+
+        {/* New Password */}
+        <motion.div
+          initial={{ x: -20, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          transition={{ duration: 0.5, delay: 0.9 }}
+        >
+          <div className="mb-4 relative">
+            <label
+              htmlFor="newPassword"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2"
+            >
+              New Password
+            </label>
+            <input
+              type={showNewPassword ? "text" : "password"}
+              placeholder="Enter New Password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="w-full p-3 rounded-lg bg-[#0f172a] text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 pr-10"
+              required
+            />
+            <button
+              type="button"
+              onClick={() => setShowNewPassword(!showNewPassword)}
+              className="absolute right-3 top-10 text-gray-400 hover:text-gray-200"
+            >
+              {showNewPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            </button>
+          </div>
+        </motion.div>
+
+        {/* Confirm Password */}
+        <motion.div
+          initial={{ x: -20, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          transition={{ duration: 0.5, delay: 0.9 }}
+        >
+          <div className="mb-6 relative">
+            <label
+              htmlFor="confirmPassword"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2"
+            >
+              Confirm Password
+            </label>
+            <input
+              type={showConfirmPassword ? "text" : "password"}
+              placeholder="Enter Confirm Password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full p-3 rounded-lg bg-[#0f172a] text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 pr-10"
+              required
+            />
+            <button
+              type="button"
+              onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+              className="absolute right-3 top-10 text-gray-400 hover:text-gray-200"
+            >
+              {showConfirmPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            </button>
+          </div>
+        </motion.div>
+
+        {/* Reset Button */}
+        <motion.div
+          initial={{ x: -20, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          transition={{ duration: 0.5, delay: 0.9 }}
+        >
+          <button
+            onClick={handleReset}
+            className="w-full bg-gradient-to-r from-purple-500 to-pink-500 text-white py-3 rounded-lg font-semibold hover:opacity-90 transition"
+          >
+            Reset Password
+          </button>
+        </motion.div>
+      </div>
+    </div>
+  );
+}
+
+export default ForgotPass;


### PR DESCRIPTION
Hello, Tushar Sonawane, GSSOC'25 Contributor, here,

Description:- 
Earlier, the project was not having the forgot password option on the sign-in page , as well as the forgot password page was also not available. But, now the "Forgot-Password" option as well as the page has been added, due to which the user can change the password if forgotten.

Issue Fixed:- #604 

Solution used:-
1. Added the forgot password option on the sign-in page.
2. That option will open new page which will have 3 inputs.
    a. Email.
    b. New Password.
    c. Confirm Password.
    d. Submit button.
3. Then there will be some conditions checked :-
    a. If New Password is less than 6 characters then it will give an alert "Password cannot be less than 6 characters".
    b. If New Password and Confirm Password are not same then it will give an alert "Confirm password is not same".
    c. If New Password and the Confirm Password is same then it will redirect to the Sign-in page.
4. After changing the password, it will automatically redirect to the sign-in page.

Images of the solution:-
1. When the new password is less than 6 characters:-
<img width="1362" height="719" alt="abcd 1" src="https://github.com/user-attachments/assets/559fd95d-c831-4c72-877b-0b3fad13d103" />

2. When the new password is not same as the confirm password:-
<img width="1362" height="716" alt="abcd 2" src="https://github.com/user-attachments/assets/931b66f1-0dfa-4425-bd8c-bcdab8def976" />

3. When the new password is same as the confirm password.
<img width="1366" height="719" alt="abcd 3" src="https://github.com/user-attachments/assets/21deefca-5d43-4c87-bebf-cc004be04fc0" />
