### PR TITLE
feat: fix registration flaw in emp role

### DIFF
--- a/server/models/Employee.js
+++ b/server/models/Employee.js
@@ -6,7 +6,7 @@ const employeeSchema = new mongoose.Schema({
   phone: { type: String },
   address: { type: String },
   experience: { type: String },
-  skills: { type: String },
+  skills: [{ type: String }],
   department: { type: String },
   workLocation: { type: String },
   profileImage: { type: String }


### PR DESCRIPTION
closes #634 
Error Details (from server console)
Employee validation failed: skills: Cast to string failed for value "[]" (type Array) at path "skills"
This indicates that the backend is expecting skills as a string, but it is receiving an array ([]) during employee registration.

Impact
Employee registration fails, preventing new employees from being added.
Frontend likely sends skills as an array, but the backend schema is not aligned with expected input format.
Suggested Resolution
Update the Mongoose schema for skills to accept an array instead of string:
skills: [{ type: String }] // instead of skills: String
Alternatively, convert array to a comma-separated string before saving if string format is preferred.
Action
Please enable the fix operation for the skills field so employee registration works as intended.