### PR TITLE
feat: created backend api for dashboard data

### DIFF
--- a/server/controllers/dashboardController.js
+++ b/server/controllers/dashboardController.js
@@ -1,0 +1,104 @@
+import User from '../models/User.js';
+import Student from '../models/Student.js';
+import Company from '../models/Company.js';
+import Employee from '../models/Employee.js';
+import Institution from '../models/Institution.js';
+
+const roleModelMap = {
+    student: Student,
+    company: Company,
+    employee: Employee,
+    institution: Institution
+};
+
+// GET /api/dashboard - returns unified dashboard data for currently authenticated user
+export const getUserDashboardData = async (req, res) => {
+    try {
+        if (!req.user?.userId) {
+            return res.status(401).json({ message: 'Unauthorized' });
+        }
+
+        const baseUser = await User.findById(req.user.userId).select('role email name');
+        if (!baseUser) {
+            return res.status(404).json({ message: 'User not found' });
+        }
+
+        const role = baseUser.role?.toLowerCase();
+        const Model = roleModelMap[role] || User;
+
+        // Fetch full document excluding password
+        const fullUser = await Model.findById(req.user.userId).select('-password');
+        if (!fullUser) {
+            return res.status(404).json({ message: 'User not found' });
+        }
+
+        // Map common fields
+        const response = {
+            name: fullUser.name || '',
+            email: fullUser.email,
+            role: role,
+            department: fullUser.department || fullUser.team || 'N/A', // Placeholder if not captured at registration
+            profileImage: fullUser.profileImage || null,
+            additionalData: {}
+        };
+
+        // Role specific enrichments
+        switch (role) {
+            case 'employee':
+                response.additionalData = {
+                    currentCompany: fullUser.currentCompany || null,
+                    jobTitle: fullUser.jobTitle || null,
+                    experience: fullUser.experience || null,
+                    skills: fullUser.skills || null,
+                    workLocation: fullUser.workLocation || null,
+                    phone: fullUser.phone || null,
+                    address: fullUser.address || null
+                };
+                break;
+            case 'student':
+                response.additionalData = {
+                    university: fullUser.university,
+                    major: fullUser.major,
+                    placementStatus: fullUser.placementStatus,
+                    resultStatus: fullUser.resultStatus,
+                    attendance: fullUser.attendance,
+                    passedInterviews: fullUser.passedInterviews,
+                    failedInterviews: fullUser.failedInterviews,
+                    year: fullUser.year,
+                    semester: fullUser.semester
+                };
+                break;
+            case 'company':
+                response.additionalData = {
+                    industry: fullUser.industry,
+                    website: fullUser.website,
+                    description: fullUser.description,
+                    foundedYear: fullUser.foundedYear,
+                    employeeCount: fullUser.employeeCount
+                };
+                break;
+            case 'institution':
+                response.additionalData = {
+                    website: fullUser.website,
+                    contactPerson: fullUser.contactPerson,
+                    establishedYear: fullUser.establishedYear,
+                    description: fullUser.description,
+                    accreditation: fullUser.accreditation,
+                    totalStudents: fullUser.totalStudents
+                };
+                break;
+            default:
+                response.additionalData = {};
+        }
+
+        // Provide minimal sample structure when fields are largely empty (useful until frontend collects more data)
+        if (Object.values(response.additionalData).every(v => v === undefined || v === null)) {
+            response.additionalData.sample = true;
+        }
+
+        return res.json(response);
+    } catch (err) {
+        console.error('Dashboard data error:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+};

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import verifyToken from '../middleware/authMiddleware.js';
+import { getUserDashboardData } from '../controllers/dashboardController.js';
+
+const router = express.Router();
+
+// Unified dashboard endpoint for any authenticated user
+router.get('/dashboard', verifyToken(), getUserDashboardData);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -24,6 +24,7 @@ import resumeRoutes from "./routes/resume.js";
 import resumeScoreRoutes from "./routes/resumeScore.js";
 import settingsRoutes from "./routes/settingsI.js";
 import companyDashboardRoutes from "./routes/companyDashboard.js";
+import dashboardRoutes from "./routes/dashboard.js";
 
 // Dry-Run routes for code validation
 import cDryRunRoutes from "./routes/cDryRun.js";
@@ -69,6 +70,8 @@ app.use("/api/settings", settingsRoutes);
 
 // Company Dashboard endpoint
 app.use("/api/company", companyDashboardRoutes);
+// Unified user dashboard endpoint
+app.use("/api", dashboardRoutes); // GET /api/dashboard
 
 // Dry-Run endpoints for code validation (Python, Java, C/C++)
 app.use("/api", dryRunRoutes); // Python dry-run: POST /api/dryrun


### PR DESCRIPTION
### Added controller getUserDashboardData in dashboardController.js that:

closes #649 

- Determines user role via base User model.
- Loads the correct discriminator model (Student, Employee, Company, Institution).
- Returns normalized JSON: { name, email, role, department, // 'N/A' fallback if missing profileImage, additionalData: { role-specific fields ... } }
- Adds additionalData.sample = true if no role-specific fields exist (useful placeholder until more data is collected).
- Handles errors: 401 (unauthorized), 404 (not found), 500 (server).
- Created new route file dashboard.js registering:

`GET /api/dashboard (protected via verifyToken())`
Updated server.js to mount the new route:

`app.use("/api", dashboardRoutes);`
Added placeholder fallback for missing department/team.

🛠 Files Added/Updated
dashboardController.js – New controller.
dashboard.js – New route.
server.js – Imported and mounted dashboard route.
📦 Response Example
`Successful call (Employee): { "name": "Jane Doe", "email": "jane@corp.com", "role": "employee", "department": "Engineering", "profileImage": "/uploads/xyz.png", "additionalData": { "currentCompany": "Acme Corp", "jobTitle": "Senior Developer", "experience": "5 years", "skills": "React,Node", "workLocation": "Remote", "phone": "1234567890", "address": "123 Tech Park" } }`

If sparse data: "additionalData": { "sample": true }

🔐 Auth
Send Authorization header: Authorization: Bearer <JWT>

```
Errors:

401: { "message": "Unauthorized" }
404: { "message": "User not found" }
```

🧩 Frontend Integration Guidance
Update places currently calling /auth/profile (e.g., EmployeeDashboardLayout.jsx, CompanyDashboardLayout.jsx, DashboardLayout.jsx) if you want the normalized structure:

```
Replace: await apiClient.get("/auth/profile")

With: const { data } = await apiClient.get("/dashboard");
```

Adjust usages:

- 
- Use data.name (fallback already handled).
- Use data.additionalData.jobTitle (for employee dashboards).
- Use data.additionalData.university / major (students).
- Use data.additionalData.industry, foundedYear (companies).
- Use data.additionalData.accreditation, totalStudents (institutions).

If some layouts still need the full raw profile (all discriminator fields), you can keep /auth/profile alongside /dashboard.

✅ Requirements Coverage
New GET endpoint /api/dashboard: Done.
Returns personal info + registration data: Done (role-mapped fields).
Auth protected: Done via verifyToken().
Response shape normalized: Done.
Error handling: Implemented.
Sample fallback: Added sample marker and 'N/A' department.
Reuse for multiple pages: Unified design supports it.
Frontend guidance: Provided above.