### PR TITLE
Add Placehodler to all the registration forms

### DIFF
--- a/src/components/FormInput.jsx
+++ b/src/components/FormInput.jsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 export default function FormInput({
   label,
+  placeholder,
   type = 'text',
   value,
   onChange,
@@ -40,6 +41,7 @@ export default function FormInput({
             type === "password" ? (showPassword ? "text" : "password") : type
           }
           value={value}
+          placeholder={placeholder}
           onChange={onChange}
           onCopy={onCopy}
           onPaste={onPaste}

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -69,9 +69,10 @@ const ContactPage = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
-  return (
+  return (    
     <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-purple-900 transition-colors duration-300">
-      
+
+
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-30">
         <div className="absolute top-20 left-10 w-72 h-72 bg-purple-200 rounded-full mix-blend-multiply filter blur-xl animate-pulse"></div>
@@ -80,7 +81,9 @@ const ContactPage = () => {
       </div>
 
       <div className="relative min-h-screen flex flex-col items-center justify-center p-4 sm:p-6 lg:p-8">
+        
         <div className="max-w-7xl w-full">
+
           {/* Header Section */}
           <motion.div
             className="text-center mb-12"

--- a/src/pages/register/CompanyForm.jsx
+++ b/src/pages/register/CompanyForm.jsx
@@ -206,6 +206,7 @@ export default function CompanyForm() {
             <FormInput
               id="company-name"
               label="Company Name"
+              placeholder="Enter Company's Name"
               value={formData.companyName}
               onChange={(e) =>
                 setFormData({ ...formData, companyName: e.target.value })
@@ -217,6 +218,7 @@ export default function CompanyForm() {
             <FormInput
               id="company-industry"
               label="Industry"
+              placeholder="Enter Industry"
               value={formData.industry}
               onChange={(e) =>
                 setFormData({ ...formData, industry: e.target.value })
@@ -228,6 +230,7 @@ export default function CompanyForm() {
             <FormInput
               id="company-website"
               label="Website"
+              placeholder="Enter Website" 
               value={formData.website}
               onChange={(e) =>
                 setFormData({ ...formData, website: e.target.value })
@@ -240,6 +243,7 @@ export default function CompanyForm() {
               id="company-hr-email"
               type="email"
               label="HR Contact Email"
+              placeholder="Enter email address"
               value={formData.email}
               onChange={(e) =>
                 setFormData({ ...formData, email: e.target.value })
@@ -252,6 +256,7 @@ export default function CompanyForm() {
               id="company-password"
               type="password"
               label="Password"
+              placeholder="Enter password"
               value={formData.password}
               onChange={handlePasswordChange}
               onCopy={(e) => e.preventDefault()}
@@ -311,6 +316,7 @@ export default function CompanyForm() {
               id="company-confirm-password"
               type="password"
               label="Confirm Password"
+              placeholder="Enter confirm password"
               value={formData.confirmPassword}
               onChange={(e) =>
                 setFormData({ ...formData, confirmPassword: e.target.value })

--- a/src/pages/register/EmployeeForm.jsx
+++ b/src/pages/register/EmployeeForm.jsx
@@ -197,6 +197,7 @@ export default function EmployeeForm() {
             <FormInput
               id="employee-fullname"
               label="Full Name"
+              placeholder="Enter your Full Name"
               value={formData.fullName}
               onChange={(e) =>
                 setFormData({ ...formData, fullName: e.target.value })
@@ -207,6 +208,7 @@ export default function EmployeeForm() {
             <FormInput
               id="employee-current-company"
               label="Current Company"
+              placeholder="Enter Current Company"
               value={formData.currentCompany}
               onChange={(e) =>
                 setFormData({ ...formData, currentCompany: e.target.value })
@@ -217,6 +219,7 @@ export default function EmployeeForm() {
             <FormInput
               id="employee-job-title"
               label="Job Title"
+              placeholder="Enter Job-title"
               value={formData.jobTitle}
               onChange={(e) =>
                 setFormData({ ...formData, jobTitle: e.target.value })
@@ -228,6 +231,7 @@ export default function EmployeeForm() {
               id="employee-email"
               type="email"
               label="Email"
+              placeholder="Enter your email"
               value={formData.email}
               onChange={(e) =>
                 setFormData({ ...formData, email: e.target.value })
@@ -239,6 +243,7 @@ export default function EmployeeForm() {
               id="employee-password"
               type="password"
               label="Password"
+              placeholder="Enter password"
               value={formData.password}
               onChange={handlePasswordChange}
               onCopy={(e) => e.preventDefault()}
@@ -298,6 +303,7 @@ export default function EmployeeForm() {
               id="employee-confirm-password"
               type="password"
               label="Confirm Password"
+              placeholder="Enter confirm password"
               value={formData.confirmPassword}
               onChange={(e) =>
                 setFormData({ ...formData, confirmPassword: e.target.value })

--- a/src/pages/register/InstitutionForm.jsx
+++ b/src/pages/register/InstitutionForm.jsx
@@ -432,6 +432,7 @@ export default function InstitutionForm() {
             <FormInput
               id="institution-name"
               label="Institution Name"
+              placeholder="Enter Institution's Name"
               value={formData.institutionName}
               onChange={(e) =>
                 handleFormDataChange("institutionName", e.target.value)
@@ -443,6 +444,7 @@ export default function InstitutionForm() {
             <FormInput
               id="institution-website"
               label="Website"
+              placeholder="Enter Institution's Website"
               type="url"
               value={formData.website}
               onChange={(e) => handleFormDataChange("website", e.target.value)}
@@ -453,6 +455,7 @@ export default function InstitutionForm() {
             <FormInput
               id="institution-contact-person"
               label="Contact Person"
+              placeholder="Enter contact person"
               value={formData.contactPerson}
               onChange={(e) =>
                 handleFormDataChange("contactPerson", e.target.value)
@@ -465,6 +468,7 @@ export default function InstitutionForm() {
               id="institution-email"
               type="email"
               label="Email"
+              placeholder="Enter email address"
               value={formData.email}
               onChange={(e) => handleFormDataChange("email", e.target.value)}
               required
@@ -475,6 +479,7 @@ export default function InstitutionForm() {
               id="institution-password"
               type="password"
               label="Password"
+              placeholder="Enter password"
               value={formData.password}
               onChange={handlePasswordChange}
               onCopy={(e) => e.preventDefault()}
@@ -534,6 +539,7 @@ export default function InstitutionForm() {
               id="institution-confirm-password"
               type="password"
               label="Confirm Password"
+              placeholder="Enter confirm password"
               value={formData.confirmPassword}
               onChange={(e) =>
                 handleFormDataChange("confirmPassword", e.target.value)

--- a/src/pages/register/StudentForm.jsx
+++ b/src/pages/register/StudentForm.jsx
@@ -213,15 +213,18 @@ export default function StudentForm() {
             <FormInput
               id="student-fullname"
               label="Full Name"
+              placeholder="Enter your Full Name"
               value={formData.fullName}
               onChange={(e) =>
                 setFormData({ ...formData, fullName: e.target.value })
               }
-              required
-            />
+              required 
+              />
+              
             <FormInput
               id="student-university"
               label="University Name"
+              placeholder="Enter your University's Name"
               value={formData.university}
               onChange={(e) =>
                 setFormData({ ...formData, university: e.target.value })
@@ -231,6 +234,7 @@ export default function StudentForm() {
             <FormInput
               id="student-major"
               label="Major/Field of Study"
+              placeholder="Enter your field of study"
               value={formData.major}
               onChange={(e) =>
                 setFormData({ ...formData, major: e.target.value })
@@ -241,6 +245,7 @@ export default function StudentForm() {
               id="student-email"
               type="email"
               label="Email"
+              placeholder="Enter your email"
               value={formData.email}
               onChange={(e) =>
                 setFormData({ ...formData, email: e.target.value })
@@ -251,6 +256,7 @@ export default function StudentForm() {
               id="student-password"
               type="password"
               label="Password"
+              placeholder="Enter password"
               value={formData.password}
               onChange={handlePasswordChange}
               onCopy={(e) => e.preventDefault()}
@@ -309,6 +315,7 @@ export default function StudentForm() {
               id="student-confirm-password"
               type="password"
               label="Confirm Password"
+              placeholder="Enter Confirm password"
               value={formData.confirmPassword}
               onChange={(e) =>
                 setFormData({ ...formData, confirmPassword: e.target.value })


### PR DESCRIPTION
### PR Description
This PR adds placeholder text to the input fields in the registration forms.

### Fixes: #629 

### Background:
Previously, the registration forms did not provide any placeholder text inside the input fields. This made it less intuitive for users to know what information is expected in each field.

### Changes Made:
Added descriptive placeholder text to all input fields (e.g., Full Name, Email, Password).
Ensured the placeholders are clear, concise, and improve form usability.
Updated the FormInput component to support the placeholder attribute.

### Impact:
Enhances user experience and form clarity.
Makes the registration process more intuitive without altering functionality.