### PR TITLE
Fix: Resolve overlapping issue between back button and Placify logo on Sign-Up page (mobile view)

### DIFF
--- a/src/components/RegistrationHeader.jsx
+++ b/src/components/RegistrationHeader.jsx
@@ -64,7 +64,7 @@ const RegistrationHeader = ({
         animate={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.5, delay: 0.2 }}
         onClick={handleBackNavigation}
-        className="absolute left-4 top-6 flex items-center space-x-2 text-white/90 hover:text-white transition-all duration-200 group bg-white/20 dark:bg-black/20 backdrop-blur-sm px-5 py-3 rounded-full hover:bg-white/30 dark:hover:bg-black/30 shadow-lg hover:shadow-xl border border-white/20 dark:border-white/10"
+        className="absolute left-3 top-3 flex items-center space-x-2 text-white/90 hover:text-white transition-all duration-200 group bg-white/20 dark:bg-black/20 backdrop-blur-sm px-5 py-3 rounded-full hover:bg-white/30 dark:hover:bg-black/30 shadow-lg hover:shadow-xl border border-white/20 dark:border-white/10"
         aria-label="Go back to previous page"
       >
         <ArrowLeft className="w-5 h-5 group-hover:-translate-x-1 transition-transform duration-200" />
@@ -82,7 +82,7 @@ const RegistrationHeader = ({
             type: "spring",
             stiffness: 200,
           }}
-          className="flex items-center justify-center space-x-3 mb-6"
+          className="flex items-center justify-center space-x-3 mb-6 mt-2"
         >
           <div className="p-2 bg-white/20 dark:bg-black/20 backdrop-blur-sm rounded-xl border border-white/30 dark:border-white/10">
             <Brain className="w-8 h-8 text-white drop-shadow-sm" />


### PR DESCRIPTION
closes #708
---

### 📋 Description  
This PR fixes the overlapping issue between the **back button** and the **Placify logo** on the **Sign-Up page** for mobile view.  
Previously, on smaller screen widths, both elements were too close, causing them to overlap and affect visibility and usability.

---

### ✅ Changes Made  
- Adjusted layout styling for the mobile header section on the Sign-Up page.  
- Added proper spacing and responsive alignment between the back button and logo.   
- Verified that the layout remains unaffected on desktop and tablet views.

---

### 📱 Before vs After  ScreenShots
#### Before
<img width="1366" height="688" alt="problem" src="https://github.com/user-attachments/assets/58a69b46-12a6-4b21-92f9-61737a304b96" />
---

#### After 

<img width="1363" height="766" alt="P1" src="https://github.com/user-attachments/assets/e5b23aba-9ac3-4a27-a7cd-5e16c8a6eb84" />
<img width="1366" height="730" alt="p2" src="https://github.com/user-attachments/assets/9edb1f03-eef3-4523-a75e-290dcbbf2c4b" />
---

### 🧪 Testing  
- Tested using Chrome DevTools responsive mode (iPhone SE, iPhone 14, Pixel 7).  
- Ensured no regressions on tablet or desktop layouts.

---

